### PR TITLE
Get the map configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,14 +102,7 @@ export class MapPlugin {
     try {
       const columns = JSON.parse(this.getAttribute("columns"))
       const geomColumn = this.getAttribute("geom") || "geometry" // default geoJSON column name
-      let mapMetric;
-      let mapZoom;
-      if (this.getAttribute("config-map")) {
-        const getConfigMap = JSON.parse(this.getAttribute("config-map"))
-        const { metric, zoom } = getConfigMap
-        mapMetric = metric;
-        mapZoom = zoom;
-      }
+      const { metric: mapMetric, zoom: mapZoom = false } = JSON.parse(this.getAttribute("config-map") || {}) || {}
 
       // Enforces to have a geometry column
       if (!columns.includes(geomColumn)) {

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,14 @@ export class MapPlugin {
     try {
       const columns = JSON.parse(this.getAttribute("columns"))
       const geomColumn = this.getAttribute("geom") || "geometry" // default geoJSON column name
-      const mapMetric = this.getAttribute("metric") // default column prop accessor
-      const mapZoom = this.getAttribute("zoom") === "true" // default column prop accessor
+      let mapMetric;
+      let mapZoom;
+      if (this.getAttribute("config-map")) {
+        const getConfigMap = JSON.parse(this.getAttribute("config-map"))
+        const { metric, zoom } = getConfigMap
+        mapMetric = metric;
+        mapZoom = zoom;
+      }
 
       // Enforces to have a geometry column
       if (!columns.includes(geomColumn)) {


### PR DESCRIPTION
Depends on https://github.com/PopulateTools/gobierto/pull/3817 Don't release a new version until the PR is merged.

The config-map is a new attribute that, for now, stores zoom and metric as values. We need to parse the config and get its attributes.