### PR TITLE
Checks if the viewer has the map-config and filtered the geometry column

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ export class MapPlugin {
 
       //Checks if the config object has been declared
       if(this.getAttribute("config-map") !== null) {
-        const { metric, zoom } = JSON.parse(this.getAttribute("config-map") || {}) || {}
+        const { metric, zoom } = JSON.parse(this.getAttribute("config-map")) || {}
         mapMetric = metric
         mapZoom = zoom || false
       }
@@ -124,7 +124,7 @@ export class MapPlugin {
       // fetch the current displayed data
       let data = await view.to_json() || []
       //Some datasets may come with an empty geometry field, so we have to filter them to avoid errors.
-      data = data.filter(({ geometry }) => geometry !== '')
+      data = data.filter(({ geometry }) => !!geometry)
       if (data.some(({ [geomColumn]: geometry }) => !!geometry)) {
 
         // get the first [key, value] from the dataset to determine its type

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,16 @@ export class MapPlugin {
     try {
       const columns = JSON.parse(this.getAttribute("columns"))
       const geomColumn = this.getAttribute("geom") || "geometry" // default geoJSON column name
-      const { metric: mapMetric, zoom: mapZoom = false } = JSON.parse(this.getAttribute("config-map") || {}) || {}
+
+      let mapZoom = false
+      let mapMetric
+
+      //Checks if the config object has been declared
+      if(this.getAttribute("config-map") !== null) {
+        const { metric, zoom } = JSON.parse(this.getAttribute("config-map") || {}) || {}
+        mapMetric = metric
+        mapZoom = zoom || false
+      }
 
       // Enforces to have a geometry column
       if (!columns.includes(geomColumn)) {
@@ -113,7 +122,9 @@ export class MapPlugin {
       const map = createMapNode(this, div, { zoom: mapZoom });
 
       // fetch the current displayed data
-      const data = await view.to_json() || []
+      let data = await view.to_json() || []
+      //Some datasets may come with an empty geometry field, so we have to filter them to avoid errors.
+      data = data.filter(({ geometry }) => geometry !== '')
       if (data.some(({ [geomColumn]: geometry }) => !!geometry)) {
 
         // get the first [key, value] from the dataset to determine its type


### PR DESCRIPTION
- Fix a bug. If the `config-map` is not defined, the map returns an error when trying to parse it. Checks if the `perspective-viewer` contains the `map-config`. [Example](https://bl.ocks.org/jorgeatgu/raw/0ec3f662231e1222b24d1a62a58780fb/?raw=true)
- In some datasets, the `geometry` row is empty. To avoid errors, those rows are filtered. [Map](https://getafe.gobify.net/datos/piramide-edad-10-barrios) --- [query](https://getafe.gobify.net/datos/piramide-edad-10-barrios/editor?sql=SELECT%2520%2a%2520FROM%2520piramide_edad_10_por_barrios%2520where%2520geometry%2520is%2520null)